### PR TITLE
<feature>:(set EntityTypeConfiguration)</feature>

### DIFF
--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/ClassifiedAd.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/ClassifiedAd.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System;
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
 
 namespace efcore.RelatedData
 {
@@ -26,7 +27,25 @@ namespace efcore.RelatedData
 
         public Guid ApproveBy { get; set; }
 
-        public List<Picture> Pictures { get; set; }
+        private List<Picture> _picture;
+
+        public IEnumerable<Picture> Pictures => _picture.AsReadOnly();
+
+        protected ClassifiedAd()
+        {
+            _picture = new List<Picture>();
+        }
+
+        public ClassifiedAd(Guid ownerId,string title):this()
+        {
+            ClassifiedAdId = Guid.NewGuid();
+            OwnerId = ownerId;
+            Title = title;
+        }
+        public void AddPicture(Picture pic)
+        {
+            _picture.Add(pic);
+        }
 
     }
 }

--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/ClassifiedAdContext.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/ClassifiedAdContext.cs
@@ -1,3 +1,4 @@
+using efcore.RelatedData.EntityTypeConfigurations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -12,6 +13,12 @@ namespace efcore.RelatedData
         public ClassifiedAdContext(DbContextOptions<ClassifiedAdContext> options):base(options)
         {
             
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new ClassifiedAdEntityTypeConfiguration());
+            modelBuilder.ApplyConfiguration(new PictureEntityTypeConfiguration());
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/EntityTypeConfigurations/ClassifiedAdEntityTypeConfiguration.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/EntityTypeConfigurations/ClassifiedAdEntityTypeConfiguration.cs
@@ -9,21 +9,31 @@ namespace efcore.RelatedData.EntityTypeConfigurations
         public void Configure(EntityTypeBuilder<ClassifiedAd> classifiedAd)
         {
             classifiedAd.HasKey(x => x.ClassifiedAdId);
+            classifiedAd.Property(x => x.ClassifiedAdId)
+                .ValueGeneratedNever()
+                .IsRequired();
+
             classifiedAd.Property(x => x.OwnerId);
-            classifiedAd.Property(x => x.Title);
-            classifiedAd.Property(x => x.Text);
-            classifiedAd.Property(x => x.CurrencyCode);
+            classifiedAd.Property(x => x.Title)
+                .HasMaxLength(150);
+            classifiedAd.Property(x => x.Text)
+                .HasMaxLength(400);
+            classifiedAd.Property(x => x.CurrencyCode)
+                .HasMaxLength(4);
             classifiedAd.Property(x => x.InUse);
-            classifiedAd.Property(x => x.DecimalPlace);
-            classifiedAd.Property(x => x.Amount);
+            classifiedAd.Property(x => x.DecimalPlace)
+                .HasColumnType("decimal(2,0)");
+            classifiedAd.Property(x => x.Amount)
+                .HasColumnType("decimal(18,2)");
             classifiedAd.Property(x => x.ApproveBy);
             classifiedAd.HasMany(c => c.Pictures)
                .WithOne()
                .HasForeignKey("ClassifiedAdId")
                .OnDelete(DeleteBehavior.Cascade);
 
-            var navigation = classifiedAd.Metadata.FindNavigation(nameof(ClassifiedAd.Pictures));
-
+            var navigation = classifiedAd.Metadata
+                .FindNavigation(nameof(ClassifiedAd.Pictures));
+            navigation.SetField("_picture");
             navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
 
         }

--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/EntityTypeConfigurations/PictureEntityTypeConfiguration.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/EntityTypeConfigurations/PictureEntityTypeConfiguration.cs
@@ -8,9 +8,13 @@ namespace efcore.RelatedData.EntityTypeConfigurations
         public void Configure(EntityTypeBuilder<Picture> builder)
         {
             builder.HasKey(x => x.PictureId);
+            builder.Property(x => x.PictureId)
+                .ValueGeneratedNever()
+                .IsRequired();
             builder.Property(x => x.Width);
             builder.Property(x => x.Height);
-            builder.Property(x => x.Location);
+            builder.Property(x => x.Location)
+                .HasMaxLength(250);
             builder.Property(x => x.Order);
         }
     }

--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/OneToMany.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/OneToMany.cs
@@ -26,30 +26,10 @@ namespace efcore.RelatedData
             using (var context = new ClassifiedAdContext())
             {
                 var rootId = Guid.NewGuid();
-                var classifiedAd = new ClassifiedAd
-                {
-                    OwnerId = Guid.NewGuid(),
-                    Title = "one to many",
-                    Pictures= new List<Picture>(){
-                        new Picture
-                        {
-                            Width = 800,
-                            Height = 600,
-                            Location = "https://google.com.tw"
-                        },      
-                        new Picture
-                        {
-                            Width = 801,
-                            Height = 601,
-                            Location = "https://yahoo.com.tw"
-                        },new Picture
-                        {
-                            Width = 802,
-                            Height = 602,
-                            Location = "https://facebook.com.tw"
-                        }
-                    }
-                };
+                var classifiedAd = new ClassifiedAd(Guid.NewGuid(), "one to many");
+                classifiedAd.AddPicture(new Picture(800,600,"https://google.com.tw",1));
+                classifiedAd.AddPicture(new Picture(801,601,"https://yahoo.com.tw",2));
+                classifiedAd.AddPicture(new Picture(802,602,"https://facebook.com.tw",3));
                 context.ClassifiedAds.Add(classifiedAd);
                 context.SaveChanges();
             }
@@ -62,10 +42,8 @@ namespace efcore.RelatedData
             using (var context = new ClassifiedAdContext())
             {
                 var classifiedAd = context.ClassifiedAds.Include(b => b.Pictures).First();
-                var picture = new Picture { 
-                    Width=803,Height=603,Location="https://yuntech.edu.tw"};
-
-                classifiedAd.Pictures.Add(picture);
+                var picture = new Picture(803, 603, "https://yuntech.edu.tw",classifiedAd.Pictures.Count()+1);
+                classifiedAd.AddPicture(picture);
                 context.SaveChanges();
             }
             #endregion

--- a/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/Picture.cs
+++ b/devops/2-code/practices/impedance-mismatch/efcore/RelatedData/Picture.cs
@@ -9,8 +9,17 @@ namespace efcore.RelatedData
         public int Height { get; set;}
         public string Location { get; set;}
         public int Order { get; set; }
-        public Guid ClassifiedAdId{ get; set; }
-        public ClassifiedAd ClassifiedAd { get; set; }
+
+        public Picture(int width,int height,string location,int order)
+        {
+            PictureId = Guid.NewGuid();
+            Width = width;
+            Height = height;
+            Location = location;
+            Order = order;
+        }
+        // public Guid ClassifiedAdId{ get; set; }
+        // public ClassifiedAd ClassifiedAd { get; set; }
 
     }
 }


### PR DESCRIPTION
解決db exception :Database operation expected to
affect 1 row(s) but actually affected 0 row(s).

原因:
若使用convention方式，欄位命名原則與設定必須符合預設，若其中一個欄位未符合慣例，則會
出現錯誤，但exception不一定完全指向慣例原則錯誤。
使用fluent API進行每個欄位設定，PK設定ValueGeneratedNever，屬性依照規格設定ColumnType，長度限制等
當model中有含list物件時，不使用public List<T>，使用IEnumerable<T>與backing field配合如下
private List<T> _list;
Public IEnumerable<T> List=>_list.AsReadOnly();
封裝集合，只允許parent model中的行為對集合進行操作，若Navigation 屬性的backing field
名稱不是慣例命名如_{camel case}，需使用額外設定SetField("<field name>")